### PR TITLE
docs(ci): add module AGENTS guidelines and verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,9 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
+      - name: Verify AGENTS guidelines
+        run: scripts/check-agents.sh
+
       # 포맷 체크 (Make 타겟 사용)
       - name: Format check
         run: make format-strict

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 gzh-cli is a comprehensive CLI tool (binary name: `gz`) for managing development environments and Git repositories across multiple platforms. It provides unified commands for repository operations, development environment management, code quality control, and network environment transitions. The project follows a simplified CLI architecture optimized for developer productivity.
 
+Each command directory under `cmd/` contains its own `AGENTS.md` with coding
+and testing conventions. Review the relevant module's file before making
+changes.
+
 ## Essential Commands
 
 ### Development Setup

--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ Flags:
 Use "gz [command] --help" for more information about a command.
 ```
 
+Each command module under `cmd/<module>` includes an `AGENTS.md` file with
+module-specific coding conventions, required tests, and review steps. Always
+consult these guidelines before modifying command implementations.
+
 ## Features
 
 ## 🔗 Git 플랫폼 통합 관리 (`gz git`)

--- a/cmd/actions-policy/AGENTS.md
+++ b/cmd/actions-policy/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS.md - actions-policy
+
+## Coding conventions
+- Use Go standard style and run `make fmt` before committing.
+- Keep Cobra command implementations simple and avoid unnecessary abstractions.
+
+## Testing and logging
+- Run `go test ./cmd/actions-policy -v` before submitting changes.
+- Prefer the repository logger for output; use `t.Logf` for test logging.
+
+## Setup and review
+- Review existing CLI flags and documentation for actions-policy before modifying.
+- Update usage examples when command behavior changes.

--- a/cmd/dev-env/AGENTS.md
+++ b/cmd/dev-env/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS.md - dev-env
+
+## Coding conventions
+- Use Go standard style and run `make fmt` before committing.
+- Keep Cobra command implementations simple and avoid unnecessary abstractions.
+
+## Testing and logging
+- Run `go test ./cmd/dev-env -v` before submitting changes.
+- Prefer the repository logger for output; use `t.Logf` for test logging.
+
+## Setup and review
+- Review existing CLI flags and documentation for dev-env before modifying.
+- Update usage examples when command behavior changes.

--- a/cmd/doctor/AGENTS.md
+++ b/cmd/doctor/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS.md - doctor
+
+## Coding conventions
+- Use Go standard style and run `make fmt` before committing.
+- Keep Cobra command implementations simple and avoid unnecessary abstractions.
+
+## Testing and logging
+- Run `go test ./cmd/doctor -v` before submitting changes.
+- Prefer the repository logger for output; use `t.Logf` for test logging.
+
+## Setup and review
+- Review existing CLI flags and documentation for doctor before modifying.
+- Update usage examples when command behavior changes.

--- a/cmd/git/AGENTS.md
+++ b/cmd/git/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS.md - git
+
+## Coding conventions
+- Use Go standard style and run `make fmt` before committing.
+- Keep Cobra command implementations simple and avoid unnecessary abstractions.
+
+## Testing and logging
+- Run `go test ./cmd/git -v` before submitting changes.
+- Prefer the repository logger for output; use `t.Logf` for test logging.
+
+## Setup and review
+- Review existing CLI flags and documentation for git before modifying.
+- Update usage examples when command behavior changes.

--- a/cmd/gz/AGENTS.md
+++ b/cmd/gz/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS.md - gz
+
+## Coding conventions
+- Use Go standard style and run `make fmt` before committing.
+- Keep Cobra command implementations simple and avoid unnecessary abstractions.
+
+## Testing and logging
+- Run `go test ./cmd/gz -v` before submitting changes.
+- Prefer the repository logger for output; use `t.Logf` for test logging.
+
+## Setup and review
+- Review existing CLI flags and documentation for gz before modifying.
+- Update usage examples when command behavior changes.

--- a/cmd/ide/AGENTS.md
+++ b/cmd/ide/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS.md - ide
+
+## Coding conventions
+- Use Go standard style and run `make fmt` before committing.
+- Keep Cobra command implementations simple and avoid unnecessary abstractions.
+
+## Testing and logging
+- Run `go test ./cmd/ide -v` before submitting changes.
+- Prefer the repository logger for output; use `t.Logf` for test logging.
+
+## Setup and review
+- Review existing CLI flags and documentation for ide before modifying.
+- Update usage examples when command behavior changes.

--- a/cmd/net-env/AGENTS.md
+++ b/cmd/net-env/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS.md - net-env
+
+## Coding conventions
+- Use Go standard style and run `make fmt` before committing.
+- Keep Cobra command implementations simple and avoid unnecessary abstractions.
+
+## Testing and logging
+- Run `go test ./cmd/net-env -v` before submitting changes.
+- Prefer the repository logger for output; use `t.Logf` for test logging.
+
+## Setup and review
+- Review existing CLI flags and documentation for net-env before modifying.
+- Update usage examples when command behavior changes.

--- a/cmd/pm/AGENTS.md
+++ b/cmd/pm/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS.md - pm
+
+## Coding conventions
+- Use Go standard style and run `make fmt` before committing.
+- Keep Cobra command implementations simple and avoid unnecessary abstractions.
+
+## Testing and logging
+- Run `go test ./cmd/pm -v` before submitting changes.
+- Prefer the repository logger for output; use `t.Logf` for test logging.
+
+## Setup and review
+- Review existing CLI flags and documentation for pm before modifying.
+- Update usage examples when command behavior changes.

--- a/cmd/profile/AGENTS.md
+++ b/cmd/profile/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS.md - profile
+
+## Coding conventions
+- Use Go standard style and run `make fmt` before committing.
+- Keep Cobra command implementations simple and avoid unnecessary abstractions.
+
+## Testing and logging
+- Run `go test ./cmd/profile -v` before submitting changes.
+- Prefer the repository logger for output; use `t.Logf` for test logging.
+
+## Setup and review
+- Review existing CLI flags and documentation for profile before modifying.
+- Update usage examples when command behavior changes.

--- a/cmd/quality/AGENTS.md
+++ b/cmd/quality/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS.md - quality
+
+## Coding conventions
+- Use Go standard style and run `make fmt` before committing.
+- Keep Cobra command implementations simple and avoid unnecessary abstractions.
+
+## Testing and logging
+- Run `go test ./cmd/quality -v` before submitting changes.
+- Prefer the repository logger for output; use `t.Logf` for test logging.
+
+## Setup and review
+- Review existing CLI flags and documentation for quality before modifying.
+- Update usage examples when command behavior changes.

--- a/cmd/registry/AGENTS.md
+++ b/cmd/registry/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS.md - registry
+
+## Coding conventions
+- Use Go standard style and run `make fmt` before committing.
+- Keep Cobra command implementations simple and avoid unnecessary abstractions.
+
+## Testing and logging
+- Run `go test ./cmd/registry -v` before submitting changes.
+- Prefer the repository logger for output; use `t.Logf` for test logging.
+
+## Setup and review
+- Review existing CLI flags and documentation for registry before modifying.
+- Update usage examples when command behavior changes.

--- a/cmd/repo-config/AGENTS.md
+++ b/cmd/repo-config/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS.md - repo-config
+
+## Coding conventions
+- Use Go standard style and run `make fmt` before committing.
+- Keep Cobra command implementations simple and avoid unnecessary abstractions.
+
+## Testing and logging
+- Run `go test ./cmd/repo-config -v` before submitting changes.
+- Prefer the repository logger for output; use `t.Logf` for test logging.
+
+## Setup and review
+- Review existing CLI flags and documentation for repo-config before modifying.
+- Update usage examples when command behavior changes.

--- a/cmd/shell/AGENTS.md
+++ b/cmd/shell/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS.md - shell
+
+## Coding conventions
+- Use Go standard style and run `make fmt` before committing.
+- Keep Cobra command implementations simple and avoid unnecessary abstractions.
+
+## Testing and logging
+- Run `go test ./cmd/shell -v` before submitting changes.
+- Prefer the repository logger for output; use `t.Logf` for test logging.
+
+## Setup and review
+- Review existing CLI flags and documentation for shell before modifying.
+- Update usage examples when command behavior changes.

--- a/cmd/synclone/AGENTS.md
+++ b/cmd/synclone/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS.md - synclone
+
+## Coding conventions
+- Use Go standard style and run `make fmt` before committing.
+- Keep Cobra command implementations simple and avoid unnecessary abstractions.
+
+## Testing and logging
+- Run `go test ./cmd/synclone -v` before submitting changes.
+- Prefer the repository logger for output; use `t.Logf` for test logging.
+
+## Setup and review
+- Review existing CLI flags and documentation for synclone before modifying.
+- Update usage examples when command behavior changes.

--- a/cmd/version/AGENTS.md
+++ b/cmd/version/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS.md - version
+
+## Coding conventions
+- Use Go standard style and run `make fmt` before committing.
+- Keep Cobra command implementations simple and avoid unnecessary abstractions.
+
+## Testing and logging
+- Run `go test ./cmd/version -v` before submitting changes.
+- Prefer the repository logger for output; use `t.Logf` for test logging.
+
+## Setup and review
+- Review existing CLI flags and documentation for version before modifying.
+- Update usage examples when command behavior changes.

--- a/scripts/check-agents.sh
+++ b/scripts/check-agents.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+missing=()
+for dir in cmd/*; do
+  [ -d "$dir" ] || continue
+  if [ ! -f "$dir/AGENTS.md" ]; then
+    missing+=("$dir/AGENTS.md")
+  fi
+done
+
+if [ ${#missing[@]} -ne 0 ]; then
+  echo "Missing AGENTS.md files:" >&2
+  printf ' - %s\n' "${missing[@]}" >&2
+  exit 1
+fi
+
+echo "All cmd modules contain AGENTS.md"


### PR DESCRIPTION
## Summary
- add `AGENTS.md` with coding and test guidance to each `cmd/*` module
- document AGENTS usage in README and CLAUDE
- verify presence of module AGENTS via new script and CI step

## Testing
- `scripts/check-agents.sh`
- `golangci-lint run -c .golangci.yml` *(no output)*
- `go test ./cmd/git -v`
- `make fmt` *(missing gofumpt, bootstrap failed)*
- `make test` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68adc735487c832aaf29937c3a63e7fe