### PR TITLE
chore: standardize on Go 1.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,6 @@ permissions:
   security-events: write
   pull-requests: write
 
-env:
-  GO_VERSION: "1.24"
-
 jobs:
   # 🧪 통합 테스트 & 커버리지
   test:
@@ -29,7 +26,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Cache Go modules
         uses: actions/cache@v4
@@ -71,7 +68,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       # 포맷 체크 (Make 타겟 사용)
       - name: Format check
@@ -103,7 +100,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Build all commands
         run: |

--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -26,9 +26,6 @@ on:
         required: false
         default: '15.0'
 
-env:
-  GO_VERSION: "1.24"
-
 jobs:
   benchmark:
     name: Performance Benchmarks
@@ -44,7 +41,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: ${{ env.GO_VERSION }}
+        go-version-file: go.mod
 
     - name: Cache Go modules
       uses: actions/cache@v4

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches: [master, main, develop]
 
-env:
-  GO_VERSION: "1.24"
-
 jobs:
   commitlint:
     name: Commit Message Lint
@@ -37,7 +34,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Run tests
         run: go test ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,6 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  GO_VERSION: "1.24"
 
 jobs:
   release:
@@ -25,7 +24,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: go.mod
 
       - name: Docker setup
         uses: docker/setup-buildx-action@v3

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 version: "2"
 run:
-  go: "1.24"
+  go: "1.22"
   modules-download-mode: readonly
   issues-exit-code: 1
   tests: true

--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ gz profile memory
 
 ## 시스템 요구사항
 
-- **Go**: 1.24.0 이상
+- **Go**: 1.22 이상
 - **Git**: 2.0 이상
 - **OS**: Linux, macOS, Windows
 

--- a/TECH_STACK.md
+++ b/TECH_STACK.md
@@ -2,7 +2,7 @@
 
 ## Core Technologies
 
-- **Language**: Go 1.24.0+ (toolchain: go1.24.5)
+- **Language**: Go 1.22.0+
 - **Framework**: Cobra CLI framework
 - **Database**: File-based configuration (YAML/JSON)
 - **Cloud Platform**: Multi-cloud support (AWS, GCP, Azure)
@@ -296,7 +296,7 @@ Unified Git platform management through `gz git` command:
 
 ### Required Tools
 
-- **Go**: 1.24.0+ (as specified in go.mod)
+- **Go**: 1.22.0+ (as specified in go.mod)
 - **Make**: For build automation
 - **Git**: 2.0+ for repository operations
 - **golangci-lint**: v2+ for code linting (auto-installed via `make bootstrap`)

--- a/cmd/doctor/doctor.go
+++ b/cmd/doctor/doctor.go
@@ -835,13 +835,11 @@ func getSystemInfo() SystemInfo {
 }
 
 func isGoVersionSupported(version string) bool {
-	// Simple check for Go 1.19+
+	// Simple check for Go 1.19 through 1.22
 	return strings.Contains(version, "go1.19") ||
 		strings.Contains(version, "go1.20") ||
 		strings.Contains(version, "go1.21") ||
-		strings.Contains(version, "go1.22") ||
-		strings.Contains(version, "go1.23") ||
-		strings.Contains(version, "go1.24")
+		strings.Contains(version, "go1.22")
 }
 
 func getDiskSpace(path string) float64 {

--- a/cmd/doctor/doctor_test.go
+++ b/cmd/doctor/doctor_test.go
@@ -79,8 +79,6 @@ func TestIsGoVersionSupported(t *testing.T) {
 		{"Go 1.20", "go1.20.1", true},
 		{"Go 1.21", "go1.21.0", true},
 		{"Go 1.22", "go1.22.1", true},
-		{"Go 1.23", "go1.23.0", true},
-		{"Go 1.24", "go1.24.0", true},
 		{"Go 1.18", "go1.18.1", false},
 		{"Go 1.17", "go1.17.1", false},
 		{"unknown", "unknown", false},
@@ -359,8 +357,6 @@ func TestIsGoVersionSupportedEdgeCases(t *testing.T) {
 		{"go1.20", true},
 		{"go1.21", true},
 		{"go1.22", true},
-		{"go1.23", true},
-		{"go1.24", true},
 		{"go1.18", false},
 		{"go2.0", false},
 	}
@@ -1535,8 +1531,6 @@ func TestDevEnvUtilityFunctions(t *testing.T) {
 			{"go1.20.0", false},
 			{"go1.21.5", false},
 			{"go1.22.0", false},
-			{"go1.23.0", false},
-			{"go1.24.0", false},
 			{"unknown", false},
 			{"", false},
 		}

--- a/docs/10-getting-started/10-installation.md
+++ b/docs/10-getting-started/10-installation.md
@@ -6,7 +6,7 @@ This guide covers the installation and initial setup of gzh-cli (`gz`).
 
 ### Prerequisites
 
-- **Go 1.24.0+** (with toolchain go1.24.5)
+- **Go 1.22.0+**
 - **Git** (any recent version)
 - **Network access** to Git platforms (GitHub, GitLab, etc.)
 
@@ -223,6 +223,6 @@ After installation, proceed to:
 
 ______________________________________________________________________
 
-**Installation Requirements**: Go 1.24.0+, Git
+**Installation Requirements**: Go 1.22.0+, Git
 **Supported Platforms**: Linux, macOS, Windows (WSL)
 **Last Updated**: 2025-08-19

--- a/docs/20-architecture/21-development-container.md
+++ b/docs/20-architecture/21-development-container.md
@@ -6,7 +6,7 @@ This document provides comprehensive guidance for using the development containe
 
 The development container provides a consistent, reproducible development environment that includes:
 
-- **Go 1.24.0** with all development tools
+- **Go 1.22.0** with all development tools
 - **Node.js 20** for React dashboard
 - **Python 3.12** for scripting
 - **Docker-in-Docker** for container development
@@ -55,7 +55,7 @@ The container is built on `mcr.microsoft.com/devcontainers/base:ubuntu-22.04` wi
 
 #### Go Development
 
-- **Go 1.24.0** - Primary language
+- **Go 1.22.0** - Primary language
 - **golangci-lint 1.63.4** - Comprehensive linting
 - **gosec** - Security analysis
 - **gofumpt** - Enhanced formatting

--- a/docs/60-development/60-index.md
+++ b/docs/60-development/60-index.md
@@ -14,7 +14,7 @@ Comprehensive development documentation for contributors and maintainers of gzh-
 
 ### Prerequisites
 
-- **Go 1.24.0+** (with toolchain go1.24.5)
+- **Go 1.22.0+**
 - **Git** (any recent version)
 - **Make** (for build automation)
 
@@ -458,7 +458,7 @@ test(github): add integration tests
 
 ______________________________________________________________________
 
-**Go Version**: 1.24.0+ (toolchain: go1.24.5)
+**Go Version**: 1.22.0+
 **Testing Framework**: Go standard library + testify
 **Mocking**: gomock
 **CLI Framework**: cobra + viper

--- a/docs/70-deployment/70-index.md
+++ b/docs/70-deployment/70-index.md
@@ -26,7 +26,7 @@ Comprehensive guide for building, releasing, and deploying gzh-cli.
 
 ### Prerequisites
 
-- **Go 1.24.0+** with toolchain go1.24.5
+- **Go 1.22.0+**
 - **Git** with proper commit access
 - **GPG Key** for signing releases
 - **GitHub CLI** for release automation
@@ -150,7 +150,7 @@ go install github.com/gizzahub/gzh-cli@v1.2.0
 
 ```dockerfile
 # Multi-stage build
-FROM golang:1.24-alpine AS builder
+FROM golang:1.22-alpine AS builder
 WORKDIR /app
 COPY . .
 RUN make build
@@ -216,7 +216,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.24'
+          go-version: '1.22'
 
       - name: Run security checks
         run: |
@@ -256,7 +256,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.24'
+          go-version: '1.22'
       - run: make test-all
 
   security:
@@ -272,7 +272,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.24'
+          go-version: '1.22'
       - run: make release
       - uses: softprops/action-gh-release@v1
         with:

--- a/docs/70-deployment/75-security-guidelines.md
+++ b/docs/70-deployment/75-security-guidelines.md
@@ -10,7 +10,7 @@ We actively maintain security updates for the following versions:
 
 | Version | Supported | Go Version | Security Features |
 | ------- | ------------------ | ---------- | ------------------- |
-| 1.x.x | :white_check_mark: | Go 1.24.0+ | Full security suite |
+| 1.x.x | :white_check_mark: | Go 1.22.0+ | Full security suite |
 | 0.x.x | :x: | Go 1.21+ | Legacy (archived) |
 
 ## Security Architecture
@@ -217,7 +217,7 @@ When deployed in containerized environments:
 
 ```dockerfile
 # Multi-stage build for minimal attack surface
-FROM golang:1.24-alpine AS builder
+FROM golang:1.22-alpine AS builder
 RUN apk add --no-cache ca-certificates git
 WORKDIR /build
 COPY . .

--- a/examples/misc/Dockerfile.example
+++ b/examples/misc/Dockerfile.example
@@ -1,5 +1,5 @@
 # Example Dockerfile for running gz in a container
-FROM golang:1.24-alpine AS builder
+FROM golang:1.22-alpine AS builder
 
 # Install build dependencies
 RUN apk add --no-cache git make

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/Gizzahub/gzh-cli
 
-go 1.24.0
-
-toolchain go1.24.5
+go 1.22
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.38.0

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -381,7 +381,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.24
+          go-version: 1.22
 
       - name: Build Application
         run: make build

--- a/test/integration/docker/README.md
+++ b/test/integration/docker/README.md
@@ -247,7 +247,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.24
+          go-version: 1.22
 
       - name: Run Docker Integration Tests
         run: |

--- a/test/integration/github/scenarios.md
+++ b/test/integration/github/scenarios.md
@@ -253,7 +253,7 @@ integration-tests:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v4
       with:
-        go-version: "1.24"
+        go-version: "1.22"
     - name: Run Integration Tests
       env:
         GITHUB_TOKEN: ${{ secrets.INTEGRATION_TEST_TOKEN }}


### PR DESCRIPTION
## Summary
- use Go 1.22 in workflows and tooling
- update doctor command version checks
- refresh documentation to reference Go 1.22

## Testing
- `go mod tidy` *(fails: gopkg.in/check.v1: Forbidden)*
- `go test ./...` *(fails: go: updates to go.mod needed; to update it: go mod tidy)*

------
https://chatgpt.com/codex/tasks/task_e_68adc991688c832a963ce40deb5ed6b6